### PR TITLE
Remove Max-Age Cache and fix sync_status order of op

### DIFF
--- a/bsync.go
+++ b/bsync.go
@@ -113,10 +113,10 @@ func Sync() bool {
 func RefreshSync() error {
 	// Set the latest block number
 	//mlog(5, "§bRefreshSync(): §7Fetching latest block number")
-	Globals.LastSyncStage = "block check"
 	latest_block, error := go_mcminterface.QueryLatestBlockNumber()
 	if error != nil {
 		mlog(3, "§bRefreshSync(): §4Error fetching latest block number: §c%s", error)
+		Globals.LastSyncStage = "latest block error"
 		Globals.IsSynced = false
 		return error
 	}
@@ -128,14 +128,15 @@ func RefreshSync() error {
 		return nil
 	}
 	mlog(4, "§bRefreshSync(): §7New block number detected: §e%d", latest_block)
+	Globals.LastSyncStage = "synchronizing"
 	Globals.IsSynced = false
 
 	// Set the hash of the latest block and the Solve Timestamp (Stime)
-	Globals.LastSyncStage = "block sync"
 	mlog(5, "§bRefreshSync(): §7Fetching latest block trailer")
 	latest_trailer, error := getBTrailer(uint32(latest_block))
 	if error != nil {
 		mlog(3, "§bRefreshSync(): §4Error fetching latest block trailer: §c%s", error)
+		Globals.LastSyncStage = "latest trailer error"
 		return error
 	}
 	Globals.LatestBlockNum = latest_block
@@ -144,10 +145,10 @@ func RefreshSync() error {
 
 	// get the last 100 block hashes and add them to the block map
 	mlog(5, "§bRefreshSync(): §7Reading latest §e100§7 blocks map from §8%s", TFILE_PATH)
-	Globals.LastSyncStage = "map update"
 	blockmap, error := readBlockMap(100, TFILE_PATH)
 	if error != nil {
 		log.Default().Println("Sync() failed: Error reading block map")
+		Globals.LastSyncStage = "block map error"
 		return error
 	}
 	for k, v := range blockmap {
@@ -162,6 +163,7 @@ func RefreshSync() error {
 	minfee_map, error := readMinFeeMap(100, TFILE_PATH)
 	if error != nil {
 		log.Default().Println("Sync() failed: Error reading minimum fee map")
+		Globals.LastSyncStage = "min fee error"
 		return error
 	}
 	for _, v := range minfee_map {

--- a/main.go
+++ b/main.go
@@ -25,7 +25,6 @@ func corsMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "*")
 		w.Header().Set("Access-Control-Allow-Headers", "*")
-		w.Header().Set("Access-Control-Max-Age", "86400")
 
 		// Handle preflight
 		if r.Method == "OPTIONS" {

--- a/network_handler.go
+++ b/network_handler.go
@@ -40,12 +40,8 @@ func networkStatusHandler(w http.ResponseWriter, r *http.Request) {
 		},
 		CurrentBlockTimestamp: int64(Globals.CurrentBlockUnixMilli),
 		GenesisBlockIdentifier: BlockIdentifier{
-			Index: 0,
+			Index: int(Globals.GenesisBlockNum),
 			Hash:  "0x" + hex.EncodeToString(Globals.GenesisBlockHash[:]),
-		},
-		OldestBlockIdentifier: BlockIdentifier{
-			Index: int(Globals.OldestBlockNum),
-			Hash:  "0x" + hex.EncodeToString(Globals.OldestBlockHash[:]),
 		},
 		SyncStatus: SyncStatus{
 			Stage:  Globals.LastSyncStage,


### PR DESCRIPTION
Just a couple of fixes for previous changes regarding the sync_status field returned by `/network/status` and removal of CORS Max Age to revert to the default of 5 seconds, as we suspect there may be some interacting issues with some browsers and their cached preflight requests.