### PR TITLE
Fix setup_database_interactive()

### DIFF
--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -358,8 +358,9 @@ main() {
         echo
         
         # Database configuration
-        DB_CONFIG=$(setup_database_interactive) || true
-        
+        DB_CONFIG=""
+        setup_database_interactive
+
         if [[ -n "$DB_CONFIG" && "$DB_CONFIG" != "false" ]]; then
             print_success "Indexer configured"
         else

--- a/tools/setup_database.sh
+++ b/tools/setup_database.sh
@@ -261,8 +261,8 @@ setup_database_interactive() {
         print_info "You can apply it later using: mysql -u$db_user -p $db_name < $SCHEMA_FILE"
     fi
     
-    # Return config as formatted string
-    echo "true|$db_host|$db_port|$db_user|$db_password|$db_name"
+    # Set config as formatted string
+    DB_CONFIG="true|$db_host|$db_port|$db_user|$db_password|$db_name"
     return 0
 }
 


### PR DESCRIPTION
Due to command substituton some output was not printed out and read from user did not work, consequently
`configuration/database.yml` was not properly updated.

-----

in `setup_database_interactive()` `db_host, db_port, db_user, db_password, db_name` were not correctly read from user, consequently not written to `configuration/database.yml`.

Example output: Even though entering all the values, values shown as empty or wrong:

```
[STEP] Updating database.yml...
[i]   enable_indexer: [STEP] Database Configuration
[i]   indexer_host: 
[i]   indexer_port: 
[i]   indexer_user: 
[i]   indexer_password: ********
[i]   indexer_database: 
[✓] database.yml updated
```


Also, for instance the output of 
`    print_step "Database Configuration"`
was not shown on the terminal, instead it ended up in `enable_indexer` variable and at the end in `configuration/database.yml`.

Seems that the problem is in command substituion `$(...)` and calling read inside it. This is unfortunately now less elegant with a "global" variable, but it works. :) 

(my environment: Ubuntu 24.04.3 LTS, and Ubuntu 25.04)


