### PR TITLE
Fix test/verify mysql connection

### DIFF
--- a/tools/setup_database.sh
+++ b/tools/setup_database.sh
@@ -12,9 +12,18 @@
 
 SCHEMA_FILE="$PROJECT_ROOT/indexer/TABLE_SCHEMA.sql"
 
+mysql_fix_host() {
+    local host="$1"
+    # Force TCP connection: mysql/mariadb will try to connect via
+    # local UNIX socket if -hlocalhost is used, which will fail in
+    # case a database server is running in a docker container.
+    [[ "$host" == "localhost" ]] && host="127.0.0.1"
+    echo "$host"
+}
+
 # Test MySQL connection
 test_mysql_connection() {
-    local host="$1"
+    local host="$(mysql_fix_host "$1")"
     local port="$2"
     local user="$3"
     local password="$4"
@@ -45,7 +54,7 @@ test_mysql_connection() {
 
 # Check if database exists
 database_exists() {
-    local host="$1"
+    local host="$(mysql_fix_host "$1")"
     local port="$2"
     local user="$3"
     local password="$4"
@@ -66,7 +75,7 @@ database_exists() {
 
 # Create database
 create_database() {
-    local host="$1"
+    local host="$(mysql_fix_host "$1")"
     local port="$2"
     local user="$3"
     local password="$4"
@@ -94,7 +103,7 @@ create_database() {
 
 # Get list of tables in database
 get_tables() {
-    local host="$1"
+    local host="$(mysql_fix_host "$1")"
     local port="$2"
     local user="$3"
     local password="$4"
@@ -109,7 +118,7 @@ get_tables() {
 
 # Apply database schema
 apply_schema() {
-    local host="$1"
+    local host="$(mysql_fix_host "$1")"
     local port="$2"
     local user="$3"
     local password="$4"

--- a/tools/verify_setup.sh
+++ b/tools/verify_setup.sh
@@ -138,10 +138,11 @@ verify_database_connection() {
     local db_port=$(grep "^indexer_port:" "$config_file" | awk '{print $2}')
     local db_user=$(grep "^indexer_user:" "$config_file" | awk '{print $2}' | tr -d '"')
     local db_name=$(grep "^indexer_database:" "$config_file" | awk '{print $2}' | tr -d '"')
-    
+    local db_password=$(grep "^indexer_password:" "$config_file" | awk '{print $2}' | tr -d '"')
+
     # Note: password should be in environment variable for security
-    local db_password="${MCM_DB_PASSWORD:-}"
-    
+    db_password="${MCM_DB_PASSWORD:-$db_password}"
+
     if test_mysql_connection "$db_host" "$db_port" "$db_user" "$db_password" "$db_name"; then
         print_success "Database connection successful"
         


### PR DESCRIPTION
Fix verifying database connectivity in case `db_host==localhost` and database running in a docker container. Force TCP in that case.

Fix `verify_database_connection()`: db_password was not read from YAMl.