### PR TITLE
Fix installing of meshapi systemd service

### DIFF
--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -145,6 +145,7 @@ extract_path_from_installation() {
 
 # Copy configuration to system directory
 install_to_system() {
+    local __returnvar=$1
     local install_dir="/opt/meshapi"
     local config_dir="$install_dir/configuration"
     local bin_dir="$install_dir/bin"
@@ -172,7 +173,7 @@ install_to_system() {
     
     print_success "Mesh API installed to $install_dir"
     
-    echo "$install_dir"
+    eval $__returnvar="$install_dir"
 }
 
 # Source utility scripts
@@ -519,7 +520,7 @@ main() {
             if [[ "$install_type" == "2" ]]; then
                 print_step "Performing system-wide installation..."
                 SYSTEM_INSTALL=true
-                INSTALL_LOCATION=$(install_to_system)
+                install_to_system INSTALL_LOCATION
                 echo
             fi
             


### PR DESCRIPTION
`install_systemd_service()` was failing due to wrong argument `$INSTALL_LOCATION` which was wrongly set due to `install_to_system() `function both printing info messages for the user to stdout and at the same time attempting to return a variable by printing it to stdout.

---

After the fix, meshapi systemd service is now successfully installed:
```
Install Mesh API as a systemd service? (Y/n): Y

[i] Installation options:
[i]   1) Local installation (run from current directory)
[i]   2) System-wide installation (install to /opt/meshapi)

Select installation type (1-2) [1]: 2
[STEP] Performing system-wide installation...
[STEP] Installing Mesh API to /opt/meshapi...
[STEP] Copying configuration files...
[STEP] Copying executable...
[✓] Mesh API installed to /opt/meshapi

[STEP] Installing meshapi systemd service...
[i] System-wide installation: /opt/meshapi
[✓] Service file created: /etc/systemd/system/meshapi.service
[STEP] Reloading systemd daemon...
[STEP] Enabling service...
Created symlink /etc/systemd/system/multi-user.target.wants/meshapi.service → /etc/systemd/system/meshapi.service.
[✓] Service enabled (will start on boot)
[✓] Service installed successfully
[i] Service will use config: /opt/meshapi/configuration/config.yml

Start Mesh API service now? (Y/n):
```
